### PR TITLE
Saebyn/issue419

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,6 @@ import ProfilePage from '@/components/pages/ProfilePage';
 import StreamManagerPage from '@/components/pages/StreamManagerPage';
 import StreamWidget from '@/components/pages/StreamWidget';
 import { TimerManagerProvider } from '@/hooks/useTimers';
-import { WebsocketProvider } from '@/hooks/useWebsocket';
 import Layout from '@/ra/Layout';
 import authProvider from '@/ra/authProvider';
 import dataProvider from '@/ra/dataProvider';
@@ -26,7 +25,6 @@ import { AdapterLuxon } from '@mui/x-date-pickers/AdapterLuxon';
 import { QueryClient } from '@tanstack/react-query';
 
 const {
-  VITE_WEBSOCKET_URL: WEBSOCKET_URL,
   VITE_QUERY_STALE_TIME: QUERY_STALE_TIME = 30 * 1000, // 30 seconds
 } = import.meta.env;
 
@@ -157,9 +155,7 @@ function App() {
 function AppProviders({ children }: { children: React.ReactNode }) {
   return (
     <LocalizationProvider dateAdapter={AdapterLuxon}>
-      <WebsocketProvider url={WEBSOCKET_URL}>
-        <TimerManagerProvider>{children}</TimerManagerProvider>
-      </WebsocketProvider>
+      <TimerManagerProvider>{children}</TimerManagerProvider>
     </LocalizationProvider>
   );
 }

--- a/src/components/organisms/TasksDrawer/Button.tsx
+++ b/src/components/organisms/TasksDrawer/Button.tsx
@@ -12,13 +12,13 @@ interface TasksStatus {
   count: number;
 }
 
-type Action = TaskStatusWebsocketMessage | { event: 'reset' };
+type Action = TaskStatusWebsocketMessage | { type: 'reset' };
 
 const TasksDrawerButton = ({ onClick }: Props) => {
   const [tasksStatus, dispatch] = useReducer<TasksStatus, [Action]>(
     (state, action) => {
-      switch (action.event) {
-        case 'task_status_change':
+      switch (action.type) {
+        case 'TASK_UPDATE':
           return {
             count: state.count + 1,
           };
@@ -52,7 +52,7 @@ const TasksDrawerButton = ({ onClick }: Props) => {
   }, [websocket]);
 
   const handleClick = useCallback(() => {
-    dispatch({ event: 'reset' });
+    dispatch({ type: 'reset' });
     onClick();
   }, [onClick]);
 

--- a/src/components/organisms/TasksDrawer/index.tsx
+++ b/src/components/organisms/TasksDrawer/index.tsx
@@ -16,9 +16,9 @@ const TasksDrawer = () => {
 
     const handle = websocket.subscribe((message) => {
       if (window.Notification && Notification.permission === 'granted') {
-        if (message.event === 'task_status_change') {
+        if (message.type === 'TASK_UPDATE') {
           new Notification(
-            `The ${message.task.task_type} task for ${message.task.record_id} is now ${message.new_status}`,
+            `The ${message.task.task_type} task for ${message.task.record_id} is now ${message.task.status} (was ${message.old_status})`,
           );
         }
       }

--- a/src/hooks/useWebsocket.tsx
+++ b/src/hooks/useWebsocket.tsx
@@ -1,7 +1,6 @@
 /**
  * websocket hook and context provider
  */
-
 import type {
   Task,
   Status as TaskStatus,
@@ -22,15 +21,14 @@ const WebsocketContext = createContext<
 export const useWebsocket = () => useContext(WebsocketContext);
 
 export interface TaskStatusWebsocketMessage {
+  type: 'TASK_UPDATE';
   task: Task;
-  previous_status: TaskStatus;
-  new_status: TaskStatus;
-  event: 'task_status_change';
+  old_status: TaskStatus;
 }
 
 export const WebsocketProvider: FC<{
   children: ReactNode;
-  url: string;
+  url: string | null;
 }> = ({ url, children }) => {
   // use useRef to keep the websocket instance between renders
   const websocket = useRef<WebSocket | undefined>(undefined);

--- a/src/ra/Layout.tsx
+++ b/src/ra/Layout.tsx
@@ -1,9 +1,21 @@
+import { WebsocketProvider } from '@/hooks/useWebsocket';
 import type { FC } from 'react';
-import { Layout } from 'react-admin';
+import { Layout, useGetIdentity } from 'react-admin';
 import AppBar from './AppBar';
 
-const MyLayout: FC<{ children?: React.ReactNode }> = ({ children }) => (
-  <Layout appBar={AppBar}>{children}</Layout>
-);
+const { VITE_WEBSOCKET_URL: WEBSOCKET_URL } = import.meta.env;
+
+const MyLayout: FC<{ children?: React.ReactNode }> = ({ children }) => {
+  const identity = useGetIdentity();
+  const accessToken = identity?.data?.idToken;
+  const websocketUrl = new URL(WEBSOCKET_URL);
+  websocketUrl.searchParams.set('token', accessToken || '');
+
+  return (
+    <WebsocketProvider url={accessToken ? websocketUrl.toString() : null}>
+      <Layout appBar={AppBar}>{children}</Layout>
+    </WebsocketProvider>
+  );
+};
 
 export default MyLayout;

--- a/src/ra/authProvider.ts
+++ b/src/ra/authProvider.ts
@@ -48,6 +48,7 @@ const authProvider: AuthProvider = {
       avatar: gravatar(user.profile.email, user.profile.name),
       email: user.profile.email,
       accessToken: user.access_token,
+      idToken: user.id_token,
     };
   },
   async handleCallback() {


### PR DESCRIPTION
This pull request removes the `WebsocketProvider` from `App.tsx` and moves it to `Layout.tsx`, updates the message type for task status changes, and makes several related adjustments. Here are the most important changes:

### Websocket Provider Refactor:
* Removed the `WebsocketProvider` from `App.tsx` and moved it to `Layout.tsx`, now wrapping the `Layout` component. This change includes dynamically setting the websocket URL with an access token. (`src/App.tsx`: [[1]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L18) [[2]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L29) [[3]](diffhunk://#diff-26ad4b834941d9b19ebf9db8082bd202aaf72ea0ddea85f5a8a0cb3c729cc6f2L160-L162) `src/ra/Layout.tsx`: [[4]](diffhunk://#diff-50ba60060aacdc707002354e25078a13dda5fb25909109b0a5e3653635ccc412R1-R19)

### Task Status Message Type Update:
* Updated the `Action` type in `TasksDrawerButton` to use `type` instead of `event`, and changed the `type` value from 'task_status_change' to 'TASK_UPDATE'. (`src/components/organisms/TasksDrawer/Button.tsx`: [[1]](diffhunk://#diff-be2dff9c6c610e8f30e2badf9808e3f9d2256b559480579d2405aebdcba15f5fL15-R21) [[2]](diffhunk://#diff-be2dff9c6c610e8f30e2badf9808e3f9d2256b559480579d2405aebdcba15f5fL55-R55)
* Updated the `TaskStatusWebsocketMessage` interface to use `type: 'TASK_UPDATE'` and renamed `previous_status` and `new_status` to `old_status` and `status`, respectively. (`src/hooks/useWebsocket.tsx`: [src/hooks/useWebsocket.tsxR24-R31](diffhunk://#diff-91bbd594b53adcfa9a9183274e86af0db887d7e91460688ae0640e6ca58ed26cR24-R31))

### Notification Message Update:
* Modified the notification message format to include both the current and previous status of the task. (`src/components/organisms/TasksDrawer/index.tsx`: [src/components/organisms/TasksDrawer/index.tsxL19-R21](diffhunk://#diff-0638c08b4a455db3f2d1b29e47f39eb30a14ca71158e1fa9b50d6f16d0d2a766L19-R21))

### Auth Provider Update:
* Added `idToken` to the user object in the `authProvider`. (`src/ra/authProvider.ts`: [src/ra/authProvider.tsR51](diffhunk://#diff-38f6a54ec6a09af288fd10c8441c11b0bd7220c4a5fc941f268747a9a95ee11bR51))

Part of https://github.com/saebyn/glowing-telegram/issues/419