### PR TITLE
fix(streams): use start_time for offsets, cursor pagination loop in data provider

### DIFF
--- a/src/hooks/useBulkEpisodeCreate.ts
+++ b/src/hooks/useBulkEpisodeCreate.ts
@@ -6,11 +6,7 @@ import type {
 } from '@saebyn/glowing-telegram-types';
 import type { VideoClip as InputVideoClip } from '@saebyn/glowing-telegram-video-editor';
 import { useMutation } from '@tanstack/react-query';
-import {
-  useDataProvider,
-  useNotify,
-  useReference,
-} from 'react-admin';
+import { useDataProvider, useNotify, useReference } from 'react-admin';
 import convertEpisodeToCutList from '@/utilities/convertEpisodeToCutList';
 import { convertSecondsToISODuration } from '@/utilities/isoDuration';
 
@@ -98,11 +94,9 @@ export default function useBulkEpisodeCreate(
     action: bulkCreateEpisodes,
     isLoading: isLoadingSeries,
     isPending,
-    errors: [
-      errorSeries,
-      mutationError,
-      validationError,
-    ].filter((error) => !!error),
+    errors: [errorSeries, mutationError, validationError].filter(
+      (error) => !!error,
+    ),
   };
 }
 
@@ -127,7 +121,9 @@ function validateState(
     const prev = streamMedia[i - 1];
     const current = streamMedia[i];
     if ((prev.start_time ?? 0) > (current.start_time ?? 0)) {
-      return new Error('Stream media must be sorted by start_time in ascending order');
+      return new Error(
+        'Stream media must be sorted by start_time in ascending order',
+      );
     }
   }
 

--- a/src/hooks/useBulkEpisodeCreate.ts
+++ b/src/hooks/useBulkEpisodeCreate.ts
@@ -8,14 +8,16 @@ import type { VideoClip as InputVideoClip } from '@saebyn/glowing-telegram-video
 import { useMutation } from '@tanstack/react-query';
 import {
   useDataProvider,
-  useGetManyReference,
   useNotify,
   useReference,
 } from 'react-admin';
 import convertEpisodeToCutList from '@/utilities/convertEpisodeToCutList';
 import { convertSecondsToISODuration } from '@/utilities/isoDuration';
 
-export default function useBulkEpisodeCreate(stream: Stream | undefined) {
+export default function useBulkEpisodeCreate(
+  stream: Stream | undefined,
+  streamMedia: OutputVideoClip[] | undefined,
+) {
   const notify = useNotify();
   const dataProvider = useDataProvider();
 
@@ -29,21 +31,6 @@ export default function useBulkEpisodeCreate(stream: Stream | undefined) {
     id: stream?.series_id || '', // empty string if no series_id, enabled will be false anyway
     options: { enabled: !!stream?.series_id },
   });
-
-  const {
-    data: streamMedia,
-    isLoading: isStreamMediaLoading,
-    error: streamMediaError,
-  } = useGetManyReference<Required<OutputVideoClip>>(
-    'video_clips',
-    {
-      target: 'stream_id',
-      id: stream?.id || '',
-    },
-    {
-      enabled: !!stream,
-    },
-  );
 
   const {
     mutate,
@@ -109,11 +96,10 @@ export default function useBulkEpisodeCreate(stream: Stream | undefined) {
 
   return {
     action: bulkCreateEpisodes,
-    isLoading: isLoadingSeries || isStreamMediaLoading,
+    isLoading: isLoadingSeries,
     isPending,
     errors: [
       errorSeries,
-      streamMediaError,
       mutationError,
       validationError,
     ].filter((error) => !!error),
@@ -134,6 +120,17 @@ function validateState(
   if (!streamMedia || streamMedia.length === 0) {
     return new Error('Stream media is required');
   }
+
+  // validate that the items in `streamMedia` are sorted
+  // by `start_time` in ascending order
+  for (let i = 1; i < streamMedia.length; i++) {
+    const prev = streamMedia[i - 1];
+    const current = streamMedia[i];
+    if ((prev.start_time ?? 0) > (current.start_time ?? 0)) {
+      return new Error('Stream media must be sorted by start_time in ascending order');
+    }
+  }
+
   if (!validateSeries(series)) {
     return new Error(
       'Series missing required fields: max_episode_order_index, notify_subscribers, category, tags',

--- a/src/ra/dataProvider/restDataProvider.ts
+++ b/src/ra/dataProvider/restDataProvider.ts
@@ -10,6 +10,42 @@ export interface BulkCreateParams<T = any> {
   meta?: any;
 }
 
+/**
+  * `sortData`
+  *
+  * Returns a sorted copy of the given items based on the specified field and sort order.
+  *
+  * If `field` is not provided, no sorting is applied and the original items are returned.
+  * If `sortOrder` is not provided, it defaults to descending order (DESC).
+  *
+  */
+function sortData<T extends Record<string, unknown>>(items: T[], field?: string, sortOrder?: 'ASC' | 'DESC'): T[] {
+  if (!field) {
+    return items;
+  }
+
+  // Sort items by params.sort.field and params.sort.order
+  // Copy the array to avoid mutating the cache
+  return items.slice().sort((a, b) => {
+    if (!field) {
+      return 0;
+    }
+
+    const aValue = a[field] || '';
+    const bValue = b[field] || '';
+
+    if (aValue < bValue) {
+      return sortOrder === 'ASC' ? -1 : 1;
+    }
+
+    if (aValue > bValue) {
+      return sortOrder === 'ASC' ? 1 : -1;
+    }
+
+    return 0;
+  });
+}
+
 const restDataProvider: DataProvider = {
   bulkCreate: async (resource: string, params: BulkCreateParams) => {
     console.log('BULK CREATE', resource, params);
@@ -58,31 +94,8 @@ const restDataProvider: DataProvider = {
     }
     const { items, cursor } = data;
 
-    // Sort items by params.sort.field and params.sort.order
-    // Copy the array to avoid mutating the cache
-    const sortedItems = items.slice().sort((a, b) => {
-      const field = params.sort?.field;
-
-      if (!field) {
-        return 0;
-      }
-
-      const aValue = a[field]?.toString() || '';
-      const bValue = b[field]?.toString() || '';
-
-      if (aValue < bValue) {
-        return params.sort?.order === 'ASC' ? -1 : 1;
-      }
-
-      if (aValue > bValue) {
-        return params.sort?.order === 'ASC' ? 1 : -1;
-      }
-
-      return 0;
-    });
-
     return {
-      data: sortedItems as any[],
+      data: sortData(items, params.sort?.field, params.sort?.order),
       pageInfo: {
         hasNextPage: cursor !== null,
         hasPreviousPage: page > 1,
@@ -132,8 +145,10 @@ const restDataProvider: DataProvider = {
       relatedFieldName: params.target,
     });
 
+    const items = results.items.map(cleanRecord(resource)) as any[];
+
     return {
-      data: results.items.map(cleanRecord(resource)) as any[],
+      data: sortData(items, params.sort?.field, params.sort?.order),
       pageInfo: {
         // TODO: Implement pagination
         hasNextPage: false,

--- a/src/ra/dataProvider/restDataProvider.ts
+++ b/src/ra/dataProvider/restDataProvider.ts
@@ -58,49 +58,7 @@ const restDataProvider: DataProvider = {
   getList: async (resource, params) => {
     console.log('GET LIST', resource, params);
 
-    const page = params.pagination?.page || 1;
-
-    const fetchSignature = JSON.stringify({
-      resource,
-      perPage: params.pagination?.perPage,
-      filter: params.filter,
-    });
-
-    const lastCursor = cursorPaginationCache.getNext(fetchSignature, page);
-
-    if (page > 1 && !lastCursor) {
-      // No cursor available for this page, return empty data
-      return {
-        data: [],
-        pageInfo: {
-          hasNextPage: false,
-          hasPreviousPage: page > 1,
-        },
-      };
-    }
-
-    const data: { items: any[]; cursor: string | null } =
-      await fetchResourceData(resource, undefined, 'GET', {
-        signal: params.signal,
-        params: {
-          cursor: lastCursor,
-          perPage: params.pagination?.perPage,
-          filter: params.filter,
-        },
-      });
-
-    if (data.cursor) {
-      cursorPaginationCache.set(fetchSignature, page, data.cursor);
-    }
-    const { items, cursor } = data;
-
-    return {
-      data: sortData(items, params.sort?.field, params.sort?.order),
-      pageInfo: {
-        hasNextPage: cursor !== null,
-        hasPreviousPage: page > 1,
-      },
-    };
+    return fetchPaginatedData(resource, undefined, undefined, params) as any;
   },
   getOne: async (resource, params) => {
     console.log('GET ONE', resource, params);
@@ -138,23 +96,7 @@ const restDataProvider: DataProvider = {
   getManyReference: async (resource, params) => {
     console.log('GET MANY REFERENCE', resource, params);
 
-    const results = await fetchResourceData<{
-      items: Record<string, unknown>[];
-    }>(resource, params.id, 'GET', {
-      signal: params.signal,
-      relatedFieldName: params.target,
-    });
-
-    const items = results.items.map(cleanRecord(resource)) as any[];
-
-    return {
-      data: sortData(items, params.sort?.field, params.sort?.order),
-      pageInfo: {
-        // TODO: Implement pagination
-        hasNextPage: false,
-        hasPreviousPage: false,
-      },
-    };
+    return fetchPaginatedData(resource, params.id, params.target, params) as any;
   },
   create: async (resource, params) => {
     console.log('CREATE', resource, params);
@@ -209,6 +151,69 @@ const restDataProvider: DataProvider = {
 };
 
 export default restDataProvider;
+
+async function fetchPaginatedData(
+  resource: string,
+  recordId: Identifier | undefined,
+  relatedFieldName: string | undefined,
+  params: {
+    pagination?: { page?: number; perPage?: number };
+    filter?: any;
+    sort?: { field?: string; order?: string };
+    signal?: AbortSignal;
+  },
+) {
+  const page = params.pagination?.page || 1;
+
+  const fetchSignature = JSON.stringify({
+    resource,
+    recordId,
+    relatedFieldName,
+    perPage: params.pagination?.perPage,
+    filter: params.filter,
+  });
+
+  const lastCursor = cursorPaginationCache.getNext(fetchSignature, page);
+
+  if (page > 1 && !lastCursor) {
+    return {
+      data: [],
+      pageInfo: {
+        hasNextPage: false,
+        hasPreviousPage: true,
+      },
+    };
+  }
+
+  const data: { items: any[]; cursor: string | null } =
+    await fetchResourceData(resource, recordId, 'GET', {
+      signal: params.signal,
+      relatedFieldName,
+      params: {
+        cursor: lastCursor,
+        perPage: params.pagination?.perPage,
+        filter: params.filter,
+      },
+    });
+
+  if (data.cursor) {
+    cursorPaginationCache.set(fetchSignature, page, data.cursor);
+  }
+
+  const { items, cursor } = data;
+
+  return {
+    data: sortData(
+      items.map(cleanRecord(resource)),
+      params.sort?.field,
+      params.sort?.order as 'ASC' | 'DESC' | undefined,
+    ) as any[],
+    pageInfo: {
+      hasNextPage: cursor !== null,
+      hasPreviousPage: page > 1,
+    },
+  };
+}
 
 function getResourceUrl(
   resource: string,

--- a/src/ra/dataProvider/restDataProvider.ts
+++ b/src/ra/dataProvider/restDataProvider.ts
@@ -11,15 +11,19 @@ export interface BulkCreateParams<T = any> {
 }
 
 /**
-  * `sortData`
-  *
-  * Returns a sorted copy of the given items based on the specified field and sort order.
-  *
-  * If `field` is not provided, no sorting is applied and the original items are returned.
-  * If `sortOrder` is not provided, it defaults to descending order (DESC).
-  *
-  */
-function sortData<T extends Record<string, unknown>>(items: T[], field?: string, sortOrder?: 'ASC' | 'DESC'): T[] {
+ * `sortData`
+ *
+ * Returns a sorted copy of the given items based on the specified field and sort order.
+ *
+ * If `field` is not provided, no sorting is applied and the original items are returned.
+ * If `sortOrder` is not provided, it defaults to descending order (DESC).
+ *
+ */
+function sortData<T extends Record<string, unknown>>(
+  items: T[],
+  field?: string,
+  sortOrder?: 'ASC' | 'DESC',
+): T[] {
   if (!field) {
     return items;
   }
@@ -96,7 +100,12 @@ const restDataProvider: DataProvider = {
   getManyReference: async (resource, params) => {
     console.log('GET MANY REFERENCE', resource, params);
 
-    return fetchPaginatedData(resource, params.id, params.target, params) as any;
+    return fetchPaginatedData(
+      resource,
+      params.id,
+      params.target,
+      params,
+    ) as any;
   },
   create: async (resource, params) => {
     console.log('CREATE', resource, params);

--- a/src/ra/dataProvider/restDataProvider.ts
+++ b/src/ra/dataProvider/restDataProvider.ts
@@ -35,8 +35,8 @@ function sortData<T extends Record<string, unknown>>(
       return 0;
     }
 
-    const aValue = a[field] || '';
-    const bValue = b[field] || '';
+    const aValue = a[field] ?? '';
+    const bValue = b[field] ?? '';
 
     if (aValue < bValue) {
       return sortOrder === 'ASC' ? -1 : 1;

--- a/src/ra/dataProvider/restDataProvider.ts
+++ b/src/ra/dataProvider/restDataProvider.ts
@@ -185,26 +185,41 @@ async function fetchPaginatedData(
     };
   }
 
-  const data: { items: any[]; cursor: string | null } =
-    await fetchResourceData(resource, recordId, 'GET', {
-      signal: params.signal,
-      relatedFieldName,
-      params: {
-        cursor: lastCursor,
-        perPage: params.pagination?.perPage,
-        filter: params.filter,
-      },
-    });
+  const perPage = params.pagination?.perPage ?? 10;
+  const allItems: any[] = [];
+  let cursor: string | null = lastCursor ?? null;
+  let isFirstFetch = true;
 
-  if (data.cursor) {
-    cursorPaginationCache.set(fetchSignature, page, data.cursor);
+  while (allItems.length < perPage) {
+    // Only use lastCursor on the first fetch; subsequent fetches use the
+    // cursor returned by the previous response.
+    if (!isFirstFetch && cursor === null) {
+      break;
+    }
+
+    const data: { items: any[]; cursor: string | null } =
+      await fetchResourceData(resource, recordId, 'GET', {
+        signal: params.signal,
+        relatedFieldName,
+        params: {
+          cursor: isFirstFetch ? lastCursor : cursor,
+          perPage: params.pagination?.perPage,
+          filter: params.filter,
+        },
+      });
+
+    cursor = data.cursor;
+    allItems.push(...data.items);
+    isFirstFetch = false;
   }
 
-  const { items, cursor } = data;
+  if (cursor) {
+    cursorPaginationCache.set(fetchSignature, page, cursor);
+  }
 
   return {
     data: sortData(
-      items.map(cleanRecord(resource)),
+      allItems.map(cleanRecord(resource)),
       params.sort?.field,
       params.sort?.order as 'ASC' | 'DESC' | undefined,
     ) as any[],

--- a/src/resources/projects/Edit.tsx
+++ b/src/resources/projects/Edit.tsx
@@ -1,7 +1,7 @@
 import { Card, CardContent, CardHeader, Typography } from '@mui/material';
-import { lazy, useEffect, useMemo, useState } from 'react';
 import type { StreamClip, VideoClip } from '@saebyn/glowing-telegram-types';
 import type { VideoClip as EditorVideoClip } from '@saebyn/glowing-telegram-video-editor';
+import { lazy, useEffect, useMemo, useState } from 'react';
 
 const ProjectClipPool = lazy(async () => {
   const { ProjectClipPool } = await import(

--- a/src/resources/projects/Edit.tsx
+++ b/src/resources/projects/Edit.tsx
@@ -1,4 +1,5 @@
 import { Card, CardContent, CardHeader, Typography } from '@mui/material';
+import { lazy, useEffect, useMemo, useState } from 'react';
 import type { StreamClip, VideoClip } from '@saebyn/glowing-telegram-types';
 import type { VideoClip as EditorVideoClip } from '@saebyn/glowing-telegram-video-editor';
 
@@ -10,7 +11,6 @@ const ProjectClipPool = lazy(async () => {
   return { default: ProjectClipPool };
 });
 
-import { lazy, useEffect, useMemo, useState } from 'react';
 import {
   Edit,
   type EditProps,

--- a/src/resources/streams/Show.tsx
+++ b/src/resources/streams/Show.tsx
@@ -21,10 +21,14 @@ const StreamShow = (props: ShowProps) => (
       <TextField source="id" />
       <DateField source="prefix" />
 
-      <ReferenceManyField reference="video_clips" target="stream_id" sort={{
-        field: 'start_time',
-        order: 'ASC',
-      }}>
+      <ReferenceManyField
+        reference="video_clips"
+        target="stream_id"
+        sort={{
+          field: 'start_time',
+          order: 'ASC',
+        }}
+      >
         <Datagrid>
           <TextField source="key" />
           <NumberField source="start_time" />

--- a/src/resources/streams/Show.tsx
+++ b/src/resources/streams/Show.tsx
@@ -21,7 +21,10 @@ const StreamShow = (props: ShowProps) => (
       <TextField source="id" />
       <DateField source="prefix" />
 
-      <ReferenceManyField reference="video_clips" target="stream_id">
+      <ReferenceManyField reference="video_clips" target="stream_id" sort={{
+        field: 'start_time',
+        order: 'ASC',
+      }}>
         <Datagrid>
           <TextField source="key" />
           <NumberField source="start_time" />

--- a/src/resources/streams/VideoEditor.tsx
+++ b/src/resources/streams/VideoEditor.tsx
@@ -40,6 +40,10 @@ function VideoEditor() {
     {
       target: 'stream_id',
       id,
+      pagination: {
+        perPage: 20,
+        page: 1,
+      },
       sort: {
         field: 'start_time',
         order: 'ASC',

--- a/src/resources/streams/VideoEditor.tsx
+++ b/src/resources/streams/VideoEditor.tsx
@@ -47,7 +47,7 @@ function VideoEditor() {
       sort: {
         field: 'start_time',
         order: 'ASC',
-      }
+      },
     },
     {
       enabled: !!id,

--- a/src/resources/streams/VideoEditor.tsx
+++ b/src/resources/streams/VideoEditor.tsx
@@ -145,8 +145,6 @@ function getVideoClipAnnotations(videoClips: VideoClip[]): {
   const silences: Section[] = [];
   const transcript: TranscriptSegment[] = [];
 
-  console.log('all clips', videoClips);
-
   for (const videoClip of videoClips) {
     if (videoClip.start_time === undefined) {
       throw new Error('Video clip has no start time');

--- a/src/resources/streams/VideoEditor.tsx
+++ b/src/resources/streams/VideoEditor.tsx
@@ -32,13 +32,7 @@ function VideoEditor() {
   } = useGetOne<Stream>('streams', { id });
 
   const {
-    action: handleBulkCreateEpisodes,
-    errors: bulkCreateEpisodesErrors,
-    isLoading: isBulkCreateEpisodesLoading,
-  } = useBulkEpisodeCreate(stream);
-
-  const {
-    data: rawRelatedVideoClips,
+    data: videoClips,
     isPending: isRelatedVideoClipsPending,
     error: relatedVideoClipsError,
   } = useGetManyReference<Required<VideoClip>>(
@@ -46,11 +40,21 @@ function VideoEditor() {
     {
       target: 'stream_id',
       id,
+      sort: {
+        field: 'start_time',
+        order: 'ASC',
+      }
     },
     {
       enabled: !!id,
     },
   );
+
+  const {
+    action: handleBulkCreateEpisodes,
+    errors: bulkCreateEpisodesErrors,
+    isLoading: isBulkCreateEpisodesLoading,
+  } = useBulkEpisodeCreate(stream, videoClips);
 
   const handleExport = (clips: InputVideoClip[]) => {
     setSelectedClips(clips);
@@ -86,19 +90,6 @@ function VideoEditor() {
   ) {
     return <LoadingIndicator />;
   }
-
-  // Make a copy of the video clips so we can sort them
-  const videoClips = [...(rawRelatedVideoClips ?? [])];
-
-  videoClips.sort((a, b) => {
-    if (a.key < b.key) {
-      return -1;
-    }
-    if (a.key > b.key) {
-      return 1;
-    }
-    return 0;
-  });
 
   // Calculate the total length of the video clips in milliseconds
   const length = videoClips.reduce(
@@ -150,12 +141,14 @@ function getVideoClipAnnotations(videoClips: VideoClip[]): {
   const silences: Section[] = [];
   const transcript: TranscriptSegment[] = [];
 
-  let offsetMs = 0;
+  console.log('all clips', videoClips);
 
   for (const videoClip of videoClips) {
-    if (!videoClip.metadata?.format?.duration) {
-      throw new Error('Video clip has no duration');
+    if (videoClip.start_time === undefined) {
+      throw new Error('Video clip has no start time');
     }
+
+    const offsetMs = videoClip.start_time * 1000.0;
 
     for (const attention of videoClip.summary?.attentions ?? []) {
       attentions.push({
@@ -197,15 +190,7 @@ function getVideoClipAnnotations(videoClips: VideoClip[]): {
         text: segment.text,
       });
     }
-
-    offsetMs += videoClip.metadata.format.duration * 1000;
   }
-
-  attentions.sort((a, b) => a.timestamp - b.timestamp);
-  highlights.sort((a, b) => a.timestamp - b.timestamp);
-  transcriptionErrors.sort((a, b) => a.timestamp - b.timestamp);
-  silences.sort((a, b) => a.timestamp - b.timestamp);
-  transcript.sort((a, b) => a.timestamp - b.timestamp);
 
   return {
     attentions,


### PR DESCRIPTION
## Summary

- Replace key-based sorting and cumulative duration offsets with `start_time` for correct annotation timestamps in the video editor
- Extract `fetchPaginatedData` helper shared by `getList` and `getManyReference`, giving the latter real cursor-based pagination
- Loop `fetchResourceData` calls until the requested page size is satisfied or the server has no more results
- Move `streamMedia` fetching into `VideoEditor` and pass it down to `useBulkEpisodeCreate`; add sort-order validation before bulk episode creation